### PR TITLE
add pkg-config to build.sh

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -116,6 +116,7 @@ libtool:libtoolize
 automake:aclocal
 autoconf:autoconf
 automake:automake
+pkg-config:pkg-config
 .
 )
 


### PR DESCRIPTION
Hi!
During the building of `rtorrent-ps`, I found that I'm also missing `pkg-config`, about which the `build.sh` didn't tell me before.
It was an easy enough fix, but it still might be useful for somebody else!