### PR TITLE
Display values of 1 throttle.up and/or 1 throttle.down in the first part of status bar

### DIFF
--- a/docs/RtorrentExtended.md
+++ b/docs/RtorrentExtended.md
@@ -16,6 +16,7 @@
     * [log.messages=«path»](#logmessagespath)
     * [network.history.*=](#networkhistory)
     * [system.env=«name» (merged into 0.9.7 )](#systemenvname-merged-into-097)
+    * [ui.status.throttle_up_name.set="«name»"](#uistatusthrottle_up_namesetname)
   * [Backports of git master fixes and features to 0.9.2](#backports-of-git-master-fixes-and-features-to-092)
 
 
@@ -266,6 +267,28 @@ Configuration example:
 
 ```ini
 session.path.set="$cat=\"$system.env=RTORRENT_HOME\",\"/.session\""
+```
+
+
+### ui.status.throttle_up_name.set="«name»"
+
+Displays values of the given throttle.up in the first part of status bar.
+Include the max limit of the throttle, the main upload rate and the upload rate of the throttle (in this order).
+
+Original: ``[Throttle 500/1500 KB] [Rate: 441.6/981.3 KB]``
+
+Modified: ``[Throttle 500 (200)/1500 KB] [Rate: 441.6 (190.0|51.6)/981.3 KB]``
+
+This extra info isn't displayed in the following cases:
+
+  * there isn't any throttle.up name as the config variable suggest or the given name is "NULL"
+  * the throttle.up is not throttled (=0)
+  * the global upload is not throttled (=0) (throttle.up won't be taken into account in this case)
+
+Configuration example:
+
+```ini
+ui.status.throttle_up_name.set="slowup"
 ```
 
 </dd>

--- a/docs/RtorrentExtended.md
+++ b/docs/RtorrentExtended.md
@@ -16,7 +16,8 @@
     * [log.messages=«path»](#logmessagespath)
     * [network.history.*=](#networkhistory)
     * [system.env=«name» (merged into 0.9.7 )](#systemenvname-merged-into-097)
-    * [ui.status.throttle_up_name.set="«name»"](#uistatusthrottle_up_namesetname)
+    * [ui.status.throttle.up.name.set="«name»"](#uistatusthrottleupnamesetname)
+    * [ui.status.throttle.down.name.set="«name»"](#uistatusthrottledownnamesetname)
   * [Backports of git master fixes and features to 0.9.2](#backports-of-git-master-fixes-and-features-to-092)
 
 
@@ -270,25 +271,35 @@ session.path.set="$cat=\"$system.env=RTORRENT_HOME\",\"/.session\""
 ```
 
 
-### ui.status.throttle_up_name.set="«name»"
+### ui.status.throttle.up.name.set="«name»"
 
-Displays values of the given throttle.up in the first part of status bar.
-Include the max limit of the throttle, the main upload rate and the upload rate of the throttle (in this order).
+### ui.status.throttle.down.name.set="«name»"
+
+Displays values of the given ``throttle.up``/``throttle.down`` in the first part of status bar.
+Include the max limit of the throttle, the main upload/download rate and the upload/download rate of the throttle (in this order).
 
 Original: ``[Throttle 500/1500 KB] [Rate: 441.6/981.3 KB]``
 
-Modified: ``[Throttle 500 (200)/1500 KB] [Rate: 441.6 (190.0|51.6)/981.3 KB]``
+Modified possible cases:
+
+```
+[Throttle 200 / 500 KB] [Rate 107.4 / 298.6 KB]
+[Throttle 200(114) / 500 KB] [Rate 107.0(1.0|105.9) / 307.6 KB]
+[Throttle 200 / 500(250) KB] [Rate 124.7 / 298.2(298.2|0.0) KB]
+[Throttle 200(114) / 500(250) KB] [Rate 115.9(1.7|114.2) / 333.9(333.9|0.0) KB]
+```
 
 This extra info isn't displayed in the following cases:
 
-  * there isn't any throttle.up name as the config variable suggest or the given name is "NULL"
-  * the throttle.up is not throttled (=0)
-  * the global upload is not throttled (=0) (throttle.up won't be taken into account in this case)
+  * there isn't any ``throttle.up``/``throttle.down`` name as the config variable suggest or the given name is "NULL"
+  * ``throttle.up``/``throttle.down`` is not throttled (=0)
+  * the global upload/download is not throttled (=0) (``throttle.up``/``throttle.down`` won't be taken into account in this case)
 
 Configuration example:
 
 ```ini
-ui.status.throttle_up_name.set="slowup"
+ui.status.throttle.up.name.set="slowup"
+ui.status.throttle.down.name.set="slowdown"
 ```
 
 </dd>

--- a/patches/ps-display-throttle-speed_all.patch
+++ b/patches/ps-display-throttle-speed_all.patch
@@ -1,80 +1,125 @@
 --- rel-0.9.6/src/command_ui.cc		2015-09-03 20:03:30.000000000 +0100
-+++ rtorrent-0.9.6/src/command_ui.cc	2016-04-24 16:01:30.677239294 +0100
-@@ -578,4 +578,6 @@ initialize_command_ui() {
++++ rtorrent-0.9.6/src/command_ui.cc	2016-08-08 11:15:30.981091307 +0100
+@@ -548,6 +548,8 @@ initialize_command_ui() {
+   // Commands that affect the default rtorrent UI.
+   CMD2_DL        ("ui.unfocus_download",   tr1::bind(&cmd_ui_unfocus_download, tr1::placeholders::_1));
+   CMD2_ANY_STRING("ui.current_view.set",   tr1::bind(&cmd_ui_set_view, tr1::placeholders::_2));
++  CMD2_VAR_STRING("ui.status.throttle.up.name",   "");
++  CMD2_VAR_STRING("ui.status.throttle.down.name", "");
  
-   CMD2_ANY_LIST ("elapsed.less",         tr1::bind(&apply_elapsed_less, tr1::placeholders::_2));
-   CMD2_ANY_LIST ("elapsed.greater",      tr1::bind(&apply_elapsed_greater, tr1::placeholders::_2));
-+
-+  CMD2_VAR_STRING("ui.status.throttle_up_name", "");
- }
+   // Move.
+   CMD2_ANY("print", &apply_print);
 --- rel-0.9.6/src/display/utils.cc	2015-08-08 16:40:41.000000000 +0100
-+++ rtorrent-0.9.6/src/display/utils.cc	2016-04-24 19:54:07.811627006 +0100
-@@ -257,21 +257,62 @@ print_client_version(char* first, char*
++++ rtorrent-0.9.6/src/display/utils.cc	2016-08-06 23:51:22.234873771 +0100
+@@ -257,21 +257,101 @@ print_client_version(char* first, char*
    }
  }
  
 +int64_t
-+retrieve_throttle_up_value(const torrent::Object::string_type& name, bool rate) {
++retrieve_throttle_value(const torrent::Object::string_type& name, bool rate, bool up) {
 +  core::ThrottleMap::iterator itr = control->core()->throttles().find(name);
 +
 +  if (itr == control->core()->throttles().end()) {
 +    return (int64_t)-1;
 +  } else {
-+    torrent::Throttle* throttle = itr->second.first;
++    torrent::Throttle* throttle = up ? itr->second.first : itr->second.second;
++
++    // check whether the actual up/down throttle exist (one of the pair can be missing)
++    if (throttle == NULL)
++      return (int64_t)-1;
++
 +    int64_t throttle_max = (int64_t)throttle->max_rate();
++
 +    if (rate) {
++
 +      if (throttle_max > 0)
 +	return (int64_t)throttle->rate()->rate();
 +      else
 +	return (int64_t)-1;
++
 +    } else {
 +      return throttle_max;
 +    }
++
 +  }
 +}
 +
  char*
  print_status_info(char* first, char* last) {
 -  if (!torrent::up_throttle_global()->is_throttled())
-+  std::string throttle_up_name = rpc::call_command_string("ui.status.throttle_up_name").c_str();
++  std::string throttle_up_name = rpc::call_command_string("ui.status.throttle.up.name");
++  std::string throttle_down_name = rpc::call_command_string("ui.status.throttle.down.name");
 +
 +  if (!torrent::up_throttle_global()->is_throttled()) {
      first = print_buffer(first, last, "[Throttle off");
 -  else
 +  } else {
      first = print_buffer(first, last, "[Throttle %3i", torrent::up_throttle_global()->max_rate() / 1024);
-+    if (!throttle_up_name.empty() && throttle_up_name != "NULL") {
-+      int64_t throttle_up_max = retrieve_throttle_up_value(throttle_up_name, false);
-+      if (throttle_up_max > 0)
-+        first = print_buffer(first, last, " (%1.0f)", (double)throttle_up_max / 1024.0);
-+    }
-+  }
  
-   if (!torrent::down_throttle_global()->is_throttled())
-     first = print_buffer(first, last, "/off KB]");
-   else
-     first = print_buffer(first, last, "/%3i KB]", torrent::down_throttle_global()->max_rate() / 1024);
+-  if (!torrent::down_throttle_global()->is_throttled())
+-    first = print_buffer(first, last, "/off KB]");
+-  else
+-    first = print_buffer(first, last, "/%3i KB]", torrent::down_throttle_global()->max_rate() / 1024);
 -  
 -  first = print_buffer(first, last, " [Rate %5.1f/%5.1f KB]",
 -                       (double)torrent::up_rate()->rate() / 1024.0,
 -                       (double)torrent::down_rate()->rate() / 1024.0);
++    if (!throttle_up_name.empty() && throttle_up_name != "NULL") {
++      int64_t throttle_up_max = retrieve_throttle_value(throttle_up_name, false, true);
++
++      if (throttle_up_max > 0)
++        first = print_buffer(first, last, "(%1.0f)", (double)throttle_up_max / 1024.0);
++    }
++  }
++
++  if (!torrent::down_throttle_global()->is_throttled()) {
++    first = print_buffer(first, last, " / off KB]");
++  } else {
++    first = print_buffer(first, last, " / %3i", torrent::down_throttle_global()->max_rate() / 1024);
++
++    if (!throttle_down_name.empty() && throttle_down_name != "NULL") {
++      int64_t throttle_down_max = retrieve_throttle_value(throttle_down_name, false, false);
++
++      if (throttle_down_max > 0)
++        first = print_buffer(first, last, "(%1.0f)", (double)throttle_down_max / 1024.0);
++    }
++
++    first = print_buffer(first, last, " KB]");
++  }
 +
 +  double global_uprate = (double)torrent::up_rate()->rate() / 1024.0;
 +  first = print_buffer(first, last, " [Rate %5.1f", global_uprate);
 +
 +  if (!throttle_up_name.empty() && throttle_up_name != "NULL" && torrent::up_throttle_global()->is_throttled()) {
-+    int64_t throttle_uprate_b = retrieve_throttle_up_value(throttle_up_name, true);
-+    if (throttle_uprate_b > -1) {
-+      double throttle_uprate = (double)throttle_uprate_b / 1024.0;
++    int64_t throttle_uprate_value = retrieve_throttle_value(throttle_up_name, true, true);
++
++    if (throttle_uprate_value > -1) {
++      double throttle_uprate = (double)throttle_uprate_value / 1024.0;
 +      double main_uprate = global_uprate - throttle_uprate;
 +
-+      first = print_buffer(first, last, " (%3.1f|%3.1f)",
++      first = print_buffer(first, last, "(%3.1f|%3.1f)",
 +                       main_uprate < 0.0 ? 0.0 : main_uprate,
 +                       throttle_uprate);
 +    }
 +  }
 +
-+  first = print_buffer(first, last, "/%5.1f KB]", (double)torrent::down_rate()->rate() / 1024.0);
++  double global_downrate = (double)torrent::down_rate()->rate() / 1024.0;
++  first = print_buffer(first, last, " / %5.1f", global_downrate);
++
++  if (!throttle_down_name.empty() && throttle_down_name != "NULL" && torrent::down_throttle_global()->is_throttled()) {
++    int64_t throttle_downrate_value = retrieve_throttle_value(throttle_down_name, true, false);
++
++    if (throttle_downrate_value > -1) {
++      double throttle_downrate = (double)throttle_downrate_value / 1024.0;
++      double main_downrate = global_downrate - throttle_downrate;
++
++      first = print_buffer(first, last, "(%3.1f|%3.1f)",
++                       main_downrate < 0.0 ? 0.0 : main_downrate,
++                       throttle_downrate);
++    }
++  }
++
++  first = print_buffer(first, last, " KB]");
  
    first = print_buffer(first, last, " [Port: %i]", (unsigned int)torrent::connection_manager()->listen_port());
  

--- a/patches/ps-display-throttle-speed_all.patch
+++ b/patches/ps-display-throttle-speed_all.patch
@@ -1,0 +1,80 @@
+--- rel-0.9.6/src/command_ui.cc		2015-09-03 20:03:30.000000000 +0100
++++ rtorrent-0.9.6/src/command_ui.cc	2016-04-24 16:01:30.677239294 +0100
+@@ -578,4 +578,6 @@ initialize_command_ui() {
+ 
+   CMD2_ANY_LIST ("elapsed.less",         tr1::bind(&apply_elapsed_less, tr1::placeholders::_2));
+   CMD2_ANY_LIST ("elapsed.greater",      tr1::bind(&apply_elapsed_greater, tr1::placeholders::_2));
++
++  CMD2_VAR_STRING("ui.status.throttle_up_name", "");
+ }
+--- rel-0.9.6/src/display/utils.cc	2015-08-08 16:40:41.000000000 +0100
++++ rtorrent-0.9.6/src/display/utils.cc	2016-04-24 19:54:07.811627006 +0100
+@@ -257,21 +257,62 @@ print_client_version(char* first, char*
+   }
+ }
+ 
++int64_t
++retrieve_throttle_up_value(const torrent::Object::string_type& name, bool rate) {
++  core::ThrottleMap::iterator itr = control->core()->throttles().find(name);
++
++  if (itr == control->core()->throttles().end()) {
++    return (int64_t)-1;
++  } else {
++    torrent::Throttle* throttle = itr->second.first;
++    int64_t throttle_max = (int64_t)throttle->max_rate();
++    if (rate) {
++      if (throttle_max > 0)
++	return (int64_t)throttle->rate()->rate();
++      else
++	return (int64_t)-1;
++    } else {
++      return throttle_max;
++    }
++  }
++}
++
+ char*
+ print_status_info(char* first, char* last) {
+-  if (!torrent::up_throttle_global()->is_throttled())
++  std::string throttle_up_name = rpc::call_command_string("ui.status.throttle_up_name").c_str();
++
++  if (!torrent::up_throttle_global()->is_throttled()) {
+     first = print_buffer(first, last, "[Throttle off");
+-  else
++  } else {
+     first = print_buffer(first, last, "[Throttle %3i", torrent::up_throttle_global()->max_rate() / 1024);
++    if (!throttle_up_name.empty() && throttle_up_name != "NULL") {
++      int64_t throttle_up_max = retrieve_throttle_up_value(throttle_up_name, false);
++      if (throttle_up_max > 0)
++        first = print_buffer(first, last, " (%1.0f)", (double)throttle_up_max / 1024.0);
++    }
++  }
+ 
+   if (!torrent::down_throttle_global()->is_throttled())
+     first = print_buffer(first, last, "/off KB]");
+   else
+     first = print_buffer(first, last, "/%3i KB]", torrent::down_throttle_global()->max_rate() / 1024);
+-  
+-  first = print_buffer(first, last, " [Rate %5.1f/%5.1f KB]",
+-                       (double)torrent::up_rate()->rate() / 1024.0,
+-                       (double)torrent::down_rate()->rate() / 1024.0);
++
++  double global_uprate = (double)torrent::up_rate()->rate() / 1024.0;
++  first = print_buffer(first, last, " [Rate %5.1f", global_uprate);
++
++  if (!throttle_up_name.empty() && throttle_up_name != "NULL" && torrent::up_throttle_global()->is_throttled()) {
++    int64_t throttle_uprate_b = retrieve_throttle_up_value(throttle_up_name, true);
++    if (throttle_uprate_b > -1) {
++      double throttle_uprate = (double)throttle_uprate_b / 1024.0;
++      double main_uprate = global_uprate - throttle_uprate;
++
++      first = print_buffer(first, last, " (%3.1f|%3.1f)",
++                       main_uprate < 0.0 ? 0.0 : main_uprate,
++                       throttle_uprate);
++    }
++  }
++
++  first = print_buffer(first, last, "/%5.1f KB]", (double)torrent::down_rate()->rate() / 1024.0);
+ 
+   first = print_buffer(first, last, " [Port: %i]", (unsigned int)torrent::connection_manager()->listen_port());
+ 


### PR DESCRIPTION
Display values of 1 throttle.up and/or 1 throttle.down in the first part of status bar.

Refers to: https://github.com/chros73/rtorrent-ps/issues/37
