### PR TITLE
Fix scheduled sorting/filtering bug on started and stopped views in rtorrent

### DIFF
--- a/patches/ps-fix-sort-started-stopped-views_all.patch
+++ b/patches/ps-fix-sort-started-stopped-views_all.patch
@@ -1,0 +1,13 @@
+--- rel-0.9.6/src/core/view.cc	2015-09-03 20:03:30.000000000 +0100
++++ rtorrent-0.9.6/src/core/view.cc	2016-07-06 17:13:47.180101179 +0100
+@@ -257,6 +257,10 @@ View::sort() {
+ 
+ void
+ View::filter() {
++  // Do NOT allow filter STARTED and STOPPED views: they are special
++  if (m_name == "started" || m_name == "stopped")
++    return;
++
+   // Parition the list in two steps so we know which elements changed.
+   iterator splitVisible  = std::stable_partition(begin_visible(),  end_visible(),  view_downloads_filter(m_filter));
+   iterator splitFiltered = std::stable_partition(begin_filtered(), end_filtered(), view_downloads_filter(m_filter));


### PR DESCRIPTION
Fixes: https://github.com/rakshasa/rtorrent/issues/449
Refers to: https://github.com/chros73/rtorrent-ps/issues/19

I've also created a pull request in `rtorrent` project for this, but who knows what will happen to it. :) We can remove it later if it will be accepted.
https://github.com/rakshasa/rtorrent/pull/451
