### PR TITLE
Expose meta property of downloads in rtorrent

### DIFF
--- a/docs/RtorrentExtended.md
+++ b/docs/RtorrentExtended.md
@@ -16,6 +16,7 @@
     * [log.messages=«path»](#logmessagespath)
     * [network.history.*=](#networkhistory)
     * [system.env=«name» (merged into 0.9.7 )](#systemenvname-merged-into-097)
+    * [d.is_meta=](#dis_meta)
   * [Backports of git master fixes and features to 0.9.2](#backports-of-git-master-fixes-and-features-to-092)
 
 
@@ -267,6 +268,11 @@ Configuration example:
 ```ini
 session.path.set="$cat=\"$system.env=RTORRENT_HOME\",\"/.session\""
 ```
+
+
+### d.is_meta=
+
+Returns boolean, determines whether a download is meta download of magnet URI.
 
 </dd>
 

--- a/patches/ps-add-magnet-property_all.patch
+++ b/patches/ps-add-magnet-property_all.patch
@@ -1,0 +1,10 @@
+--- rel-0.9.6/src/command_download.cc	2016-07-20 11:44:57.000000000 +0100
++++ rtorrent-0.9.6/src/command_download.cc	2016-07-20 12:50:16.000000000 +0100
+@@ -683,6 +683,7 @@ initialize_command_download() {
+   CMD2_DL         ("d.is_pex_active",         CMD2_ON_INFO(is_pex_active));
+   CMD2_DL         ("d.is_partially_done",     CMD2_ON_DATA(is_partially_done));
+   CMD2_DL         ("d.is_not_partially_done", CMD2_ON_DATA(is_not_partially_done));
++  CMD2_DL         ("d.is_meta",               CMD2_ON_INFO(is_meta_download));
+ 
+   CMD2_DL_V       ("d.resume",     tr1::bind(&core::DownloadList::resume_default, control->core()->download_list(), tr1::placeholders::_1));
+   CMD2_DL_V       ("d.pause",      tr1::bind(&core::DownloadList::pause_default, control->core()->download_list(), tr1::placeholders::_1));


### PR DESCRIPTION
Expose meta property `d.is_meta` of downloads in rtorrent: it can be useful when dealing with magnet links and using e.g. `event.download.erased` in our config.

Note: `all` in the name of patch means v0.9.2 or newer.
I've also created a pull request in rtorrent project.
