### PR TITLE
Modify link for font-linking in main readme file

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -201,7 +201,7 @@ Read these instructions:
 -  `(Windows) Terminal
    Setup <https://github.com/pyroscope/rtorrent-ps/blob/master/docs/RtorrentExtendedCanvas.md#setting-up-your-terminal>`_,
    and `Font Linking on
-   Windows <https://github.com/chros73/rtorrent-ps_setup/tree/master/windows-8.1#font-linking-on-windows>`_
+   Windows <https://github.com/chros73/rtorrent-ps_setup/wiki/Windows-8.1#font-linking-on-windows>`_
 
 If all else fails, you can add a `configuration
 snippet <http://community.rutorrent.org/RtorrentColorThemes#rT-PS:_8_color_scheme_for_badly_configured_terminals>`_


### PR DESCRIPTION
Modify link for font-linking in main `readme` file, since I put the docs of my project into WIKI.