### PR TITLE
Pick / copy rt-ps-ch patches / backports

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -401,7 +401,7 @@ extend() { # Rebuild and install libtorrent and rTorrent with patches applied
     # Patch libtorrent
     pushd libtorrent-$LT_VERSION
 
-    for backport in $SRC_DIR/patches/{backport,trac,misc}_${LT_VERSION%-svn}_*.patch; do
+    for backport in $SRC_DIR/patches/{backport,trac,misc}_{${LT_VERSION%-svn},all}_*.patch; do
         test ! -e "$backport" || { bold "$(basename $backport)"; patch -uNp0 -i "$backport"; }
     done
 
@@ -447,7 +447,7 @@ clean() { # Clean up generated files
 }
 
 clean_all() { # Remove all downloads and created files
-    rm tarballs/*.tar.gz tarballs/DONE >/dev/null || :
+    test ! -d tarballs || rm tarballs/*.tar.gz tarballs/DONE >/dev/null || :
     for i in $SUBDIRS; do
         test ! -d $i || rm -rf $i >/dev/null
     done


### PR DESCRIPTION
Add ability in build script to use 'all' word in `librottent` patches not just a version number:
- it applies to all the types: `backport`, `trac`, `misc`
- only for `libtorrent` patches (`ps-*_all.patch` for `rtorrent` must be used instead)

Also fix trying to delete `tarballs` dir when script runs for the first time.
