### PR TITLE
Fix honoring system.file.allocate.set=[0|1] rtorrent config setting

### DIFF
--- a/patches/misc_all_honor_system_file_allocate_fix.patch
+++ b/patches/misc_all_honor_system_file_allocate_fix.patch
@@ -1,0 +1,22 @@
+--- src/torrent/data/file.cc	2015-08-08 16:01:49.000000000 +0100
++++ src/torrent/data/file.cc	2016-08-21 22:11:53.000144395 +0100
+@@ -168,13 +168,14 @@ File::resize_file() {
+   if (m_size == SocketFile(m_fd).size())
+     return true;
+ 
+-  // For now make it so that the fallocate flag indicates if we want
+-  // to do potentially blocking allocation, while FS supported
+-  // non-blocking allocation is done always.
+-  int flags = SocketFile::flag_fallocate;
++  int flags = 0;
+ 
+-  if (m_flags & flag_fallocate)
++  // Set FS supported non-blocking allocation flag and potentially
++  // blocking allocation flag if fallocate flag is set.
++  if (m_flags & flag_fallocate) {
++    flags |= SocketFile::flag_fallocate;
+     flags |= SocketFile::flag_fallocate_blocking;
++  }
+ 
+   return SocketFile(m_fd).set_size(m_size, flags);
+ }

--- a/patches/misc_all_honor_system_file_allocate_fix.patch
+++ b/patches/misc_all_honor_system_file_allocate_fix.patch
@@ -1,5 +1,16 @@
+--- src/download/download_wrapper.cc	2015-08-08 16:01:49.000000000 +0100
++++ src/download/download_wrapper.cc	2016-08-23 18:06:34.346151049 +0100
+@@ -343,6 +343,8 @@ DownloadWrapper::receive_update_prioriti
+       data()->mutable_high_priority()->insert((*itr)->range().first, (*itr)->range().second);
+       break;
+     default:
++      // Unset fallocate flag if priority of a file is Off.
++      (*itr)->unset_flags(File::flag_fallocate);
+       break;
+     }
+   }
 --- src/torrent/data/file.cc	2015-08-08 16:01:49.000000000 +0100
-+++ src/torrent/data/file.cc	2016-08-21 22:11:53.000144395 +0100
++++ src/torrent/data/file.cc	2016-08-23 12:59:32.115952838 +0100
 @@ -168,13 +168,14 @@ File::resize_file() {
    if (m_size == SocketFile(m_fd).size())
      return true;
@@ -20,3 +31,34 @@
  
    return SocketFile(m_fd).set_size(m_size, flags);
  }
+--- src/torrent/data/file_list.cc	2015-08-08 16:01:32.000000000 +0100
++++ src/torrent/data/file_list.cc	2016-08-23 17:17:19.248826853 +0100
+@@ -580,7 +580,12 @@ FileList::open_file(File* node, const Pa
+     return false;
+   }
+ 
+-  return node->prepare(MemoryChunk::prot_read, 0);
++  // File allocation will be done if fallocate flag is set,
++  // create zero-length file otherwise.
++  if (node->has_flags(File::flag_fallocate))
++    return node->prepare(MemoryChunk::prot_write, 0);
++  else
++    return node->prepare(MemoryChunk::prot_read, 0);
+ }
+ 
+ MemoryChunk
+--- src/torrent/download.cc	2015-08-08 16:01:49.000000000 +0100
++++ src/torrent/download.cc	2016-08-23 18:14:20.843623816 +0100
+@@ -131,9 +131,9 @@ Download::start(int flags) {
+ 
+ //   file_list()->open(flags);
+ 
+-  // If the FileList::open_no_create flag was not set, our new
+-  // behavior is to create all zero-length files with
+-  // flag_queued_create set.
++  // If the open_enable_fallocate or the FileList::open_no_create
++  // flag was not set, then create all zero-length files with
++  // flag_create_queued set.
+   file_list()->open(flags & ~FileList::open_no_create);
+ 
+   if (m_ptr->connection_type() == CONNECTION_INITIAL_SEED) {


### PR DESCRIPTION
A. Fix honoring `system.file.allocate.set=0` rtorrent config setting in libtorrent.

B. Fix honoring `system.file.allocate.set=1` rtorrent config setting in libtorrent:
- allocate space for those files only that don't have priority set to `off`.

It's useful with the following watch directory entry that only loads (in `closed` state) but not starts torrents, so priority of files can be set.
`schedule2 = watch_dir_5,  7, 10, "load.normal=/path/to/watch-dir/load_but_not_start/*.torrent"`

C. This patch is also good for: 0.13.6, 0.13.4, 0.13.2 .

Note:
this patch depends on: https://github.com/pyroscope/rtorrent-ps/pull/40
