### PR TITLE
Check that libtool exists properly

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -414,7 +414,9 @@ build_deps() {
     $SED_I s:/usr/local:$INSTALL_DIR: \
         $INSTALL_DIR/bin/xmlrpc-c-config
 
-    $(which libtool true) --finish $INSTALL_DIR/lib
+    if command which libtool >/dev/null; then
+        libtool --finish $INSTALL_DIR/lib
+    fi
     touch $INSTALL_DIR/lib/DEPS-DONE
 }
 


### PR DESCRIPTION
On Debian 8, `which libtool true` returns
```
/usr/bin/libtool
true: shell built-in command
```
which makes the call fail with
```
libtool: you must specify a MODE
libtool: Try `libtool --help' for more information.
```