### PR TITLE
Apply OpenSSL 1.1 patch using version detection of itself (not distribution)

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -113,13 +113,11 @@ case $(echo -n "$(lsb_release -sic 2>/dev/null || echo NonLSB)" | tr ' \n' '-') 
     *-vivid|*-wily|*-xenial|*-yakkety|*-zesty)
         ;;
     *-stretch|*-buster|Fedora-TwentySix)
-        LT_BASE_PATCHES+=( $SRC_DIR/patches/lt-open-ssl-1.1.patch )
         ;;
     Arch-*) # 0.9.[46] only!
         BUILD_PKG_DEPS=( ncurses openssl cppunit )
         source /etc/makepkg.conf 2>/dev/null
         MAKE_OPTS="${MAKEFLAGS}${MAKE_OPTS:+ }${MAKE_OPTS}"
-        LT_BASE_PATCHES+=( $SRC_DIR/patches/lt-open-ssl-1.1.patch )
         ;;
     NonLSB)
         # Place tests for MacOSX etc. here
@@ -127,6 +125,13 @@ case $(echo -n "$(lsb_release -sic 2>/dev/null || echo NonLSB)" | tr ' \n' '-') 
         echo
         echo "*** Build dependencies are NOT pre-checked on this platform! ***"
         echo
+        ;;
+esac
+
+# OpenSSL version detection for patch
+case $(openssl version 2> /dev/null | grep -o "1.1.[0-9]") in
+    1.1.*)
+        LT_BASE_PATCHES+=( $SRC_DIR/patches/lt-open-ssl-1.1.patch )
         ;;
 esac
 


### PR DESCRIPTION
The `build.sh`'s selection control mechanism for adding `lt-open-ssl-1.1.patch` to `LT_BASE_PATCHES` is currently handled based on the *distribution release name*, but this strategy is flawed as the release name alone does not directly correlate to the `openssl` package version.

For example: I am running Ubuntu `17.10` (`artful`), which ships with `openssl@1.0.2g`. Based on the current detection strategy, the patch for `1.1` would not be applied. **But**, I utilize the extremely common [PHP PPA by Ondřej Surý](https://launchpad.net/~ondrej/+archive/ubuntu/php), which provides an updated `openssl@1.1.0g` package; the current implementation does not detect this as it performs no version checks against the actual package, causing the `rtorrent-ps` build to fail with compilation errors.

Instead, I propose we use the **detected openssl version**, instead of the distribution release name, to decide when the `lt-open-ssl-1.1.patch` patch should be applied. This PR does just that.

If you'd prefer the detection logic was handled in a different manner, please advise. I settled on a `case` control mechanism to make it easy to apply future patches based on the `openssl` version.