### PR TITLE
Use same types for std::max

### DIFF
--- a/patches/command_pyroscope.cc
+++ b/patches/command_pyroscope.cc
@@ -665,7 +665,7 @@ torrent::Object cmd_string_substr(rpc::target_type target, const torrent::Object
         }
         offsets[idx] = bytes;
 
-        int64_t begidx = std::max(idx + glyphs, 0L);
+        int64_t begidx = std::max(idx + glyphs, (int64_t) 0);
         int64_t endidx = std::min(idx, begidx + count);
         return text.substr(offsets[begidx], offsets[endidx] - offsets[begidx]);
     }


### PR DESCRIPTION
This fixes compilation on my Arch Linux ARM system. The error message was as follows.
```
command_pyroscope.cc: In function ‘torrent::Object cmd_string_substr(rpc::target_type, const list_type&)’:
command_pyroscope.cc:668:51: error: no matching function for call to ‘max(int64_t, long int)’
         int64_t begidx = std::max(idx + glyphs, 0L);
                                                   ^
```