### PR TITLE
Ensure that ratio_col is not indexed with a negative value

### DIFF
--- a/patches/ui_pyroscope.cc
+++ b/patches/ui_pyroscope.cc
@@ -494,7 +494,7 @@ static void decorate_download_title(Window* window, display::Canvas* canvas, cor
 // show ratio progress by color (ratio is scaled x1000)
 static int ratio_color(int ratio) {
     int rcol = sizeof(ratio_col) / sizeof(*ratio_col) - 1;
-    return ratio_col[std::min(rcol, ratio * rcol / 1200)];
+    return ratio_col[std::min(rcol, std::max(0, ratio) * rcol / 1200)];
 }
 
 


### PR DESCRIPTION
I'm not sure what exactly caused it but my installation of rTorrent-PS was consistently segfaulting here. I fiddled with it a bit and it seemed that it was indexing with a negative value. As far as I can tell, there's no way for `rcol` to be negative so it must have been the ratio (couldn't tell for sure because `ratio` was optimized out and not viewable in the debugger).