### PR TITLE
Add support for Ubuntu 20.04

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -64,6 +64,7 @@ fi
 docker_distros_stable=(
     debian:stretch
     ubuntu:bionic
+    ubuntu:focal
 )
 docker_distros_oldstable=(
     debian:jessie
@@ -104,7 +105,7 @@ export PACKAGE_ROOT INSTALL_ROOT INSTALL_DIR BIN_DIR CURL_OPTS MAKE_OPTS CFG_OPT
 export SRC_DIR=$(cd $(dirname $0) && pwd)
 LT_PATCHES=( )
 RT_PATCHES=( )
-LT_BASE_PATCHES=( $SRC_DIR/patches/lt-base-cppunit-pkgconfig.patch )
+LT_BASE_PATCHES=( $SRC_DIR/patches/lt-base-cppunit-pkgconfig.patch $SRC_DIR/patches/lt-base-c11-fixes.patch )
 RT_BASE_PATCHES=( $SRC_DIR/patches/rt-base-cppunit-pkgconfig.patch )
 
 # Distro specifics
@@ -155,6 +156,7 @@ esac
 #   trusty  (14.04) 4.8.2
 #   xenial  (16.04) 5.3.1
 #   bionic  (18.04) 7.3.0
+#   focal   (20.04) 9.3.0
 #
 # Try this when you get configure errors regarding xmlrpc-c
 # ... on a Intel PC type system with certain types of CPUs:

--- a/patches/lt-base-c11-fixes.patch
+++ b/patches/lt-base-c11-fixes.patch
@@ -1,0 +1,21 @@
+diff --git a/src/net/socket_set.h b/src/net/socket_set.h
+index 6581f26d..9264edf7 100644
+--- a/src/net/socket_set.h
++++ b/src/net/socket_set.h
+@@ -53,12 +53,12 @@ namespace torrent {
+
+ // Propably should rename to EventSet...
+
+-class SocketSet : private std::vector<Event*, rak::cacheline_allocator<> > {
++class SocketSet : private std::vector<Event*, rak::cacheline_allocator<Event*> > {
+ public:
+   typedef uint32_t    size_type;
+
+-  typedef std::vector<Event*, rak::cacheline_allocator<> > base_type;
+-  typedef std::vector<size_type, rak::cacheline_allocator<> > Table;
++  typedef std::vector<Event*, rak::cacheline_allocator<Event*> > base_type;
++  typedef std::vector<size_type, rak::cacheline_allocator<size_type> > Table;
+
+   static const size_type npos = static_cast<size_type>(-1);
+
+


### PR DESCRIPTION
The patch code was taken from https://github.com/rakshasa/libtorrent/commit/77a0f35569c8e1df25f5fe9e6129a61511aa6cff#diff-c877966953bc80a41d38c813b72938e2. It's apparently always been invalid C++11, GCC just didn't start caring about it until 8.1