### PR TITLE
Fix `setup.rst` diagnostic command in documentation

### DIFF
--- a/docs/setup.rst
+++ b/docs/setup.rst
@@ -315,8 +315,7 @@ Similarly, execute this in a shell prompt:
     free -m | head -n2; uptime; \
     strings $(which rtorrent) | grep "client version"; \
     ldd $(which rtorrent) | egrep "lib(torrent|curses|curl|xmlrpc.so|cares|ssl|crypto)"; \
-    ps auxw | egrep "USER|rtorrent" | grep -v grep
-
+    ps auxw | egrep "USER|rtorrent" | grep -v grep | grep -v \\.rtorrent\\.rc
 
 Common Problems & Solutions
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/docs/setup.rst
+++ b/docs/setup.rst
@@ -315,7 +315,7 @@ Similarly, execute this in a shell prompt:
     free -m | head -n2; uptime; \
     strings $(which rtorrent) | grep "client version"; \
     ldd $(which rtorrent) | egrep "lib(torrent|curses|curl|xmlrpc.so|cares|ssl|crypto)"; \
-    ps auxw | egrep "USER|/rtorrent" | grep -v grep
+    ps auxw | egrep "USER|rtorrent" | grep -v grep
 
 
 Common Problems & Solutions


### PR DESCRIPTION
- Fix for not including the `rtorrent` process when invoked via `rtorrent`, rather than `/usr/bin/rtorrent`.
- Don't include any text editors editing `.rtorrent.rc` (For example: `nano ~/.rtorrent.rc`