### PR TITLE
Use distro automake's config.guess

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -465,6 +465,7 @@ build_deps() {
 
     ( cd xmlrpc-c-advanced-$XMLRPC_REV \
         && $SED_I s:PGROGRAMDESTDIR:PROGRAMDESTDIR: common.mk \
+        && cp /usr/share/automake-*/config.guess config.guess \
         && ./configure --prefix=$INSTALL_DIR --with-libwww-ssl \
             --disable-wininet-client --disable-curl-client --disable-libwww-client --disable-abyss-server --disable-cgi-server \
         && $MAKE $MAKE_OPTS && $MAKE DESTDIR=$INSTALL_DIR prefix= install \


### PR DESCRIPTION
Closes https://github.com/pyroscope/rtorrent-ps/issues/137

The config.guess that ships with the version of xmlrpc-c RTPS uses is quite
outdated - it's from 2009. It can't identify some modern systems,
specifically ARM64 (i.e aarch64). x86_64 is obviously okay, I expect armv7l
also as there is some mention of RPi 3's in the script.
To work around this without using a different version of xmlrpc-c, we can
simply copy in the newer config.guess that ships with the version of
automake we install from the distro. This is automake's recommended
solution. This results in a successful build on newer platforms.

Previous results:
```
#14 54.17 checking build system type... ./config.guess: unable to guess system type
#14 54.21
#14 54.21 This script, last modified 2009-12-30, has failed to recognize
#14 54.21 the operating system you are using. It is advised that you
#14 54.21 download the most up to date version of the config scripts from
#14 54.21
#14 54.21   http://git.savannah.gnu.org/gitweb/?p=config.git;a=blob_plain;f=config.guess;hb=HEAD
#14 54.21 and
#14 54.21   http://git.savannah.gnu.org/gitweb/?p=config.git;a=blob_plain;f=config.sub;hb=HEAD
#14 54.21
#14 54.21 If the version you run (./config.guess) is already up to date, please
#14 54.21 send the following data and any information you think might be
#14 54.21 pertinent to <config-patches@gnu.org> in order to provide the needed
#14 54.21 information to handle your system.
#14 54.21
#14 54.21 config.guess timestamp = 2009-12-30
#14 54.21
#14 54.21 uname -m = aarch64
#14 54.21 uname -r = 5.10.76-linuxkit
#14 54.21 uname -s = Linux
#14 54.21 uname -v = #1 SMP PREEMPT Mon Nov 8 11:22:26 UTC 2021
#14 54.21
#14 54.21 /usr/bin/uname -p =
#14 54.21 /bin/uname -X     =
#14 54.21
#14 54.21 hostinfo               =
#14 54.21 /bin/universe          =
#14 54.21 /usr/bin/arch -k       =
#14 54.21 /bin/arch              =
#14 54.21 /usr/bin/oslevel       =
#14 54.21 /usr/convex/getsysinfo =
#14 54.21
#14 54.21 UNAME_MACHINE = aarch64
#14 54.21 UNAME_RELEASE = 5.10.76-linuxkit
#14 54.21 UNAME_SYSTEM  = Linux
#14 54.21 UNAME_VERSION = #1 SMP PREEMPT Mon Nov 8 11:22:26 UTC 2021
#14 54.21 configure: error: cannot guess build type; you must specify one
#14 54.22 Cannot build or install 'xmlrpc-c'!
------
executor failed running [/bin/bash -c ./build.sh install]: exit code: 1
```

I've tested that this change builds packages successfully for:
- Debian bullseye on ARM64 
- All previously working builds on x86_64 (bionic, bullseye, buster, focal, xenial)

I have not been able to test for Arch on ARM64 as they do not supply a docker image.
